### PR TITLE
🐛 `meta.yml`: use legacy `marvel-nccr` namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   release:
     name: Publish to ansible-galaxy
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: [pre-commit]
+    needs: [pre-commit, molecule]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ allow_duplicates: false
 
 galaxy_info:
   role_name: ubuntu_desktop
-  namespace: marvel_nccr
+  namespace: marvel-nccr
   author: "MARVEL NCCR"
   # yamllint disable-line rule:line-length
   description: "An ansible role that installs & configures Ubuntu desktop on plain Ubuntu."

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,4 +10,4 @@
     when: ansible_os_family == 'Debian'
 
   roles:
-  - role: "marvel_nccr.ubuntu_desktop"
+  - role: "marvel-nccr.ubuntu_desktop"


### PR DESCRIPTION
Galaxy's legacy role importer reads the `namespace` field and tries to use it as the role namespace. However, legacy role namespaces are tied to GitHub org names (`marvel-nccr`), not collection namespaces (`marvel_nccr`). Using the collection namespace caused the import to fail with:

    "legacy namespace marvel_nccr does not exist"

We first tried to remove `galaxy_info.namespace` from `meta/main.yml` to avoid this error. However, this caused several issues:

1. Galaxy's legacy importer ignored `role_name` and derived the name from the repository (`ansible-role-ubuntu-desktop` → `ubuntu-desktop`), creating a new role instead of updating the existing `ubuntu_desktop`
2. Molecule couldn't find the role via FQCN anymore
3. Both the Ansible and Molecule linting failed, requiring workarounds to ignore the problem.

The root cause was a misunderstanding of Ansible's two namespace systems:

- **Legacy role namespaces**: Derived from GitHub org, allow hyphens (`marvel-nccr`)
- **Collection namespaces**: Must be valid Python identifiers, underscores only (`marvel_nccr`)

The fix is simply to use the correct legacy namespace:

    namespace: marvel-nccr

This satisfies Galaxy's legacy importer, Molecule's FQCN resolution, and ansible-lint.