### PR TITLE
🐛 `packages`: prevent SSH drop during desktop install

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,10 +1,23 @@
 - name: Install wm desktop (apt)
   become: true
-  ansible.builtin.apt:
-    name:
-    - "{{ ubuntu_desktop_wm_package }}" # e.g. lxde, ubuntu-desktop-minimal
-    - python3-pip
-    - python3-psutil
+  block:
+    # Installing ubuntu-desktop pulls in NetworkManager, which can cause the network
+    # interface to lose its IP mid-install. We set networkd as the renderer.
+  - name: Set netplan renderer to networkd
+    ansible.builtin.copy:
+      dest: /etc/netplan/99-stay-with-networkd.yaml
+      content: |
+        network:
+          version: 2
+          renderer: networkd
+      mode: '0600'
+
+  - name: Install wm desktop (apt)
+    ansible.builtin.apt:
+      name:
+      - "{{ ubuntu_desktop_wm_package }}" # e.g. lxde, ubuntu-desktop-minimal
+      - python3-pip
+      - python3-psutil
 
 - name: Start gdm3 service to get a graphical login
   become: true


### PR DESCRIPTION
When installing `ubuntu-desktop-minimal`, `network-manager` is pulled in as a dependency, which causes `eth0` to lose its IPv4 address mid-install, dropping the SSH connection Ansible is using to provision the machine.

Here, we add a netplan configuration file that explicitly sets `renderer: networkd` to prevent this. For Desktop VMs, `networkd` is typically fine, and NetworkManager is not needed.